### PR TITLE
Modified output plugin docs

### DIFF
--- a/docs/content/preview/explore/change-data-capture/using-logical-replication/key-concepts.md
+++ b/docs/content/preview/explore/change-data-capture/using-logical-replication/key-concepts.md
@@ -45,6 +45,8 @@ YugabyteDB supports the following four output plugins:
 
 All these plugins are pre-packaged with YugabyteDB and do not require any external installation.
 
+The plugin `yboutput` is Yugabyte specific. It is similar to `pgoutput` in most aspects. The only difference being that replica identity `CHANGE` is not supported in `pgoutput`. All other plugins support replica identity `CHANGE`.
+
 For more information, refer to [Logical Decoding Output Plugins](https://www.postgresql.org/docs/11/logicaldecoding-output-plugin.html) in the PostgreSQL documentation.
 
 ### LSN

--- a/docs/content/preview/explore/change-data-capture/using-logical-replication/key-concepts.md
+++ b/docs/content/preview/explore/change-data-capture/using-logical-replication/key-concepts.md
@@ -45,7 +45,11 @@ YugabyteDB supports the following four output plugins:
 
 All these plugins are pre-packaged with YugabyteDB and do not require any external installation.
 
-The plugin `yboutput` is Yugabyte specific. It is similar to `pgoutput` in most aspects. The only difference being that replica identity `CHANGE` is not supported in `pgoutput`. All other plugins support replica identity `CHANGE`.
+{{< note title="Note" >}}
+
+The plugin `yboutput` is YugabyteDB specific. It is similar to `pgoutput` in most aspects. The only difference being that replica identity `CHANGE` is not supported in `pgoutput`. All other plugins support replica identity `CHANGE`.
+
+{{</note>}}
 
 For more information, refer to [Logical Decoding Output Plugins](https://www.postgresql.org/docs/11/logicaldecoding-output-plugin.html) in the PostgreSQL documentation.
 


### PR DESCRIPTION
This PR modifies the output plugins documentation to add that `pgoutput` plugin doesn't support replica identity CHANGE.